### PR TITLE
Improve dark mode and responsive layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -123,7 +123,7 @@ const App = () => {
               <p className="font-semibold">{notification}</p>
             </div>
           )}
-          <div className="text-center bg-white p-8 sm:p-12 rounded-xl shadow-md border w-full max-w-full">
+          <div className="text-center bg-white p-8 sm:p-12 rounded-xl shadow-md border w-full max-w-xl">
             <h1 className="text-3xl font-extrabold text-gray-800">Architect Hiring Pipeline</h1>
             <p className="mt-2 text-gray-500">To get started, please upload your CSV file.</p>
             <button
@@ -189,7 +189,7 @@ const App = () => {
                 </div>
               </div>
             </div>
-            <main className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <main className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
               {sortedCandidates.map((candidate) => (
                 <CandidateCard
                   key={candidate.id}

--- a/src/index.css
+++ b/src/index.css
@@ -7,9 +7,10 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  /* Force a light base color scheme so Tailwind classes look consistent */
+  color-scheme: light;
+  color: #213547;
+  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -44,7 +45,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #f9f9f9;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -56,15 +57,3 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}


### PR DESCRIPTION
## Summary
- force a light color scheme in global CSS to avoid pale colors when the OS is in dark mode
- lighten default button styling
- center the initial upload prompt with a narrower width
- use four columns for candidate cards on extra-large screens

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68598fc653e083318ed4d7387bf02652