### PR TITLE
Implement sheets listing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,11 @@ curl -X POST http://localhost:4000/auth/validate \
   -H 'Content-Type: application/json' \
   -d '{"idToken":"<token>"}'
 ```
+
+### List spreadsheets
+
+Fetch accessible Google Sheets:
+
+```bash
+curl -H "Authorization: Bearer <idToken>" http://localhost:4000/sheets
+```

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -1,0 +1,26 @@
+paths:
+  /sheets:
+    get:
+      summary: List available spreadsheets
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: q
+          schema:
+            type: string
+          description: Optional case-insensitive name filter
+      responses:
+        '200':
+          description: List of spreadsheets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3,6 +3,7 @@ import express, { Request, Response, NextFunction } from 'express';
 import { google } from 'googleapis';
 import healthRouter from './routes/health';
 import authRouter from './routes/auth';
+import sheetsRouter from './routes/sheets';
 import requireAuth from './middleware/requireAuth';
 import logger from './logger';
 import { getAuth } from './lib/googleClient';
@@ -21,6 +22,7 @@ app.use('/health-protected', requireAuth, (_req, res) => {
   res.json({ status: 'ok' });
 });
 app.use('/auth', authRouter);
+app.use('/sheets', requireAuth, sheetsRouter);
 
 app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
   logger.error(err.message);

--- a/backend/src/lib/cache.ts
+++ b/backend/src/lib/cache.ts
@@ -1,0 +1,27 @@
+interface Entry<T> {
+  value: T;
+  expires: number;
+}
+
+const store = new Map<string, Entry<unknown>>();
+
+export function set<T>(key: string, value: T, ttl: number) {
+  store.set(key, { value, expires: Date.now() + ttl });
+  setTimeout(() => {
+    store.delete(key);
+  }, ttl).unref();
+}
+
+export function get<T>(key: string): T | null {
+  const entry = store.get(key);
+  if (!entry) return null;
+  if (entry.expires < Date.now()) {
+    store.delete(key);
+    return null;
+  }
+  return entry.value as T;
+}
+
+export function clear(key: string) {
+  store.delete(key);
+}

--- a/backend/src/routes/sheets.ts
+++ b/backend/src/routes/sheets.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import listSpreadsheets from '../services/driveService';
+
+const router = Router();
+
+router.get('/', async (req, res) => {
+  const q = typeof req.query.q === 'string' ? req.query.q : undefined;
+  const sheets = await listSpreadsheets(q);
+  res.json(sheets);
+});
+
+export default router;

--- a/backend/src/services/driveService.ts
+++ b/backend/src/services/driveService.ts
@@ -1,0 +1,60 @@
+import { drive } from '../lib/googleClient';
+import logger from '../logger';
+import * as cache from '../lib/cache';
+
+export interface SpreadsheetMeta {
+  id: string;
+  name: string;
+}
+
+const CACHE_KEY = 'allSheets';
+const TTL = 5 * 60 * 1000; // 5 minutes
+
+async function fetchAllSpreadsheets(): Promise<SpreadsheetMeta[]> {
+  const files: SpreadsheetMeta[] = [];
+  let pageToken: string | undefined;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        // eslint-disable-next-line no-await-in-loop
+        const res = await drive.files.list({
+          q: "mimeType='application/vnd.google-apps.spreadsheet' and trashed = false",
+          fields: 'nextPageToken, files(id, name)',
+          pageSize: 100,
+          pageToken,
+        });
+        const list = res.data.files || [];
+        list.forEach((f) => {
+          if (f.id && f.name) files.push({ id: f.id, name: f.name });
+        });
+        pageToken = res.data.nextPageToken || undefined;
+        if (!pageToken) break;
+      }
+      return files;
+    } catch (err) {
+      const delay = 2 ** attempt * 100;
+      logger.warn(
+        `Drive list attempt ${attempt + 1} failed: ${(err as Error).message}`,
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, delay);
+      });
+    }
+  }
+  throw new Error('Unable to fetch spreadsheets from Drive');
+}
+
+export default async function listSpreadsheets(
+  search?: string,
+): Promise<SpreadsheetMeta[]> {
+  let data = cache.get<SpreadsheetMeta[]>(CACHE_KEY);
+  if (!data) {
+    data = await fetchAllSpreadsheets();
+    cache.set(CACHE_KEY, data, TTL);
+  }
+  if (!search) return data;
+  const q = search.toLowerCase();
+  return data.filter((s) => s.name.toLowerCase().includes(q));
+}

--- a/backend/tests/sheets.test.ts
+++ b/backend/tests/sheets.test.ts
@@ -1,0 +1,102 @@
+import request from 'supertest';
+import { writeFileSync } from 'fs';
+import path from 'path';
+process.env.ALLOWED_USERS = 'user1@example.com';
+const dummyKey = path.join(__dirname, 'dummy.json');
+writeFileSync(dummyKey, '{}');
+process.env.SERVICE_ACCOUNT_JSON = dummyKey;
+import app from '../src/app';
+import * as cache from '../src/lib/cache';
+
+var mockedVerify: jest.Mock; // eslint-disable-line no-var
+var mockList: jest.Mock; // eslint-disable-line no-var
+
+jest.mock('google-auth-library', () => {
+  mockedVerify = jest.fn();
+  return {
+    OAuth2Client: function () {
+      return { verifyIdToken: mockedVerify };
+    },
+  };
+});
+
+jest.mock('../src/lib/googleClient', () => {
+  mockList = jest.fn();
+  return {
+    getAuth: jest.fn(),
+    sheets: {},
+    drive: { files: { list: mockList } },
+  };
+});
+jest.mock('googleapis', () => ({
+  google: {
+    oauth2: () => ({
+      userinfo: {
+        get: jest
+          .fn()
+          .mockResolvedValue({ data: { email: 'test@example.com' } }),
+      },
+    }),
+  },
+}));
+
+describe('GET /sheets', () => {
+  beforeEach(() => {
+    mockedVerify.mockReset();
+    mockList.mockReset();
+    cache.clear('allSheets');
+  });
+
+  it('returns spreadsheets', async () => {
+    mockedVerify.mockResolvedValue({
+      getPayload: () => ({ email: 'user1@example.com' }),
+    });
+    mockList.mockResolvedValueOnce({
+      data: {
+        files: [
+          { id: '1', name: 'Sheet A' },
+          { id: '2', name: 'Sheet B' },
+        ],
+      },
+    });
+    const res = await request(app)
+      .get('/sheets')
+      .set('Authorization', 'Bearer token')
+      .expect(200);
+    expect(res.body).toEqual([
+      { id: '1', name: 'Sheet A' },
+      { id: '2', name: 'Sheet B' },
+    ]);
+  });
+
+  it('filters by query', async () => {
+    mockedVerify.mockResolvedValue({
+      getPayload: () => ({ email: 'user1@example.com' }),
+    });
+    mockList.mockResolvedValueOnce({
+      data: {
+        files: [
+          { id: '1', name: 'Alpha' },
+          { id: '2', name: 'Beta' },
+        ],
+      },
+    });
+    const res = await request(app)
+      .get('/sheets?q=alp')
+      .set('Authorization', 'Bearer token')
+      .expect(200);
+    expect(res.body).toEqual([{ id: '1', name: 'Alpha' }]);
+  });
+
+  it('returns empty array when none', async () => {
+    mockedVerify.mockResolvedValue({
+      getPayload: () => ({ email: 'user1@example.com' }),
+    });
+    mockList.mockResolvedValueOnce({ data: { files: [] } });
+    const res = await request(app)
+      .get('/sheets')
+      .set('Authorization', 'Bearer token')
+      .expect(200);
+    expect(res.body).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add Drive cache helper
- implement Drive spreadsheet listing service with caching and retries
- expose protected `/sheets` route
- document new endpoint in README and OpenAPI
- test listing results and filtering

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685b0971f59c8331a6661f8e4c3adccc