### PR TITLE
feature/T6-tabs-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,12 @@ Fetch accessible Google Sheets:
 ```bash
 curl -H "Authorization: Bearer <idToken>" http://localhost:4000/sheets
 ```
+
+### List tabs for a spreadsheet
+
+Fetch worksheet names from a specific Google Sheet:
+
+```bash
+curl -H "Authorization: Bearer <idToken>" \
+     http://localhost:4000/sheets/1AbCdEfGhIjKlMnOpQrStUvWxYz/tabs
+```

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -24,3 +24,39 @@ paths:
                       type: string
                     name:
                       type: string
+
+  /sheets/{id}/tabs:
+    get:
+      summary: List spreadsheet tabs
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: Spreadsheet ID
+      responses:
+        '200':
+          description: List of tabs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    gid:
+                      type: string
+                    title:
+                      type: string
+        '404':
+          description: Spreadsheet not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,6 +4,7 @@ import { google } from 'googleapis';
 import healthRouter from './routes/health';
 import authRouter from './routes/auth';
 import sheetsRouter from './routes/sheets';
+import tabsRouter from './routes/tabs';
 import requireAuth from './middleware/requireAuth';
 import logger from './logger';
 import { getAuth } from './lib/googleClient';
@@ -23,6 +24,7 @@ app.use('/health-protected', requireAuth, (_req, res) => {
 });
 app.use('/auth', authRouter);
 app.use('/sheets', requireAuth, sheetsRouter);
+app.use('/sheets', tabsRouter);
 
 app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
   logger.error(err.message);

--- a/backend/src/routes/tabs.ts
+++ b/backend/src/routes/tabs.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import requireAuth from '../middleware/requireAuth';
+import sheetsService from '../services/sheetsService';
+
+const router = Router();
+
+router.get('/:id/tabs', requireAuth, async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const tabs = await sheetsService.listTabs(id);
+    if (!tabs) return res.status(404).json({ error: 'spreadsheet not found' });
+    return res.json(tabs);
+  } catch (err) {
+    return next(err);
+  }
+});
+
+export default router;

--- a/backend/src/services/sheetsService.ts
+++ b/backend/src/services/sheetsService.ts
@@ -1,0 +1,47 @@
+import { sheets } from '../lib/googleClient';
+import logger from '../logger';
+import * as cache from '../lib/cache';
+
+export interface SheetTab {
+  gid: string;
+  title: string;
+}
+
+const TTL = 5 * 60 * 1000; // 5 minutes
+
+export async function listTabs(sheetId: string): Promise<SheetTab[] | null> {
+  if (!sheetId || sheetId.length < 40) return null;
+  const cacheKey = `tabs:${sheetId}`;
+  let data = cache.get<SheetTab[]>(cacheKey);
+  if (data) return data;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await sheets.spreadsheets.get({
+        spreadsheetId: sheetId,
+        fields: 'sheets.properties',
+      });
+      const list = res.data.sheets;
+      if (!list) return null;
+      data = list.map((s) => ({
+        gid: String(s.properties?.sheetId ?? ''),
+        title: s.properties?.title ?? '',
+      }));
+      cache.set(cacheKey, data, TTL);
+      return data;
+    } catch (err) {
+      if ((err as { code?: number }).code === 404) return null;
+      const delay = 2 ** attempt * 100;
+      logger.warn(
+        `Sheets get attempt ${attempt + 1} failed: ${(err as Error).message}`,
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, delay);
+      });
+    }
+  }
+  throw new Error('Unable to fetch spreadsheet tabs');
+}
+
+export default { listTabs };

--- a/backend/tests/tabs.test.ts
+++ b/backend/tests/tabs.test.ts
@@ -1,0 +1,91 @@
+import request from 'supertest';
+import { writeFileSync } from 'fs';
+import path from 'path';
+process.env.ALLOWED_USERS = 'user1@example.com';
+const dummyKey = path.join(__dirname, 'dummy.json');
+writeFileSync(dummyKey, '{}');
+process.env.SERVICE_ACCOUNT_JSON = dummyKey;
+import app from '../src/app';
+import * as cache from '../src/lib/cache';
+
+var mockedVerify: jest.Mock; // eslint-disable-line no-var
+var mockGet: jest.Mock; // eslint-disable-line no-var
+
+jest.mock('google-auth-library', () => {
+  mockedVerify = jest.fn();
+  return {
+    OAuth2Client: function () {
+      return { verifyIdToken: mockedVerify };
+    },
+  };
+});
+
+jest.mock('../src/lib/googleClient', () => {
+  mockGet = jest.fn();
+  return {
+    getAuth: jest.fn(),
+    sheets: { spreadsheets: { get: mockGet } },
+    drive: {},
+  };
+});
+jest.mock('googleapis', () => ({
+  google: {
+    oauth2: () => ({
+      userinfo: {
+        get: jest
+          .fn()
+          .mockResolvedValue({ data: { email: 'test@example.com' } }),
+      },
+    }),
+  },
+}));
+
+describe('GET /sheets/:id/tabs', () => {
+  beforeEach(() => {
+    mockedVerify.mockReset();
+    mockGet.mockReset();
+    cache.clear('tabs:12345678901234567890123456789012345678901234');
+  });
+
+  it('returns tabs', async () => {
+    mockedVerify.mockResolvedValue({
+      getPayload: () => ({ email: 'user1@example.com' }),
+    });
+    mockGet.mockResolvedValueOnce({
+      data: {
+        sheets: [
+          { properties: { sheetId: 0, title: 'Candidates' } },
+          { properties: { sheetId: 123456789, title: 'Archive 2024' } },
+        ],
+      },
+    });
+    const res = await request(app)
+      .get('/sheets/12345678901234567890123456789012345678901234/tabs')
+      .set('Authorization', 'Bearer token')
+      .expect(200);
+    expect(res.body).toEqual([
+      { gid: '0', title: 'Candidates' },
+      { gid: '123456789', title: 'Archive 2024' },
+    ]);
+  });
+
+  it('returns 404 when not found', async () => {
+    mockedVerify.mockResolvedValue({
+      getPayload: () => ({ email: 'user1@example.com' }),
+    });
+    const err: any = new Error('not found');
+    err.code = 404;
+    mockGet.mockRejectedValueOnce(err);
+    const res = await request(app)
+      .get('/sheets/unknown/tabs')
+      .set('Authorization', 'Bearer token')
+      .expect(404);
+    expect(res.body).toEqual({ error: 'spreadsheet not found' });
+  });
+
+  it('requires auth', async () => {
+    await request(app)
+      .get('/sheets/12345678901234567890123456789012345678901234/tabs')
+      .expect(401);
+  });
+});


### PR DESCRIPTION
## Summary
- support listing spreadsheet tabs
- add Google Sheets service for listing tabs with caching
- document GET /sheets/{id}/tabs in README and OpenAPI spec
- cover tabs endpoint in tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685b0b582e988331a7663b9e6d5dbdd9