### PR TITLE
feat: add pipeline sync endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ coverage/
 
 # Secrets
 secrets/service-account.json
+backend/config/settings.json
 
 # Optional: if using Tailwind JIT or similar
 .tailwind-debug.log

--- a/README.md
+++ b/README.md
@@ -59,3 +59,13 @@ Fetch worksheet names from a specific Google Sheet:
 curl -H "Authorization: Bearer <idToken>" \
      http://localhost:4000/sheets/1AbCdEfGhIjKlMnOpQrStUvWxYz/tabs
 ```
+
+### Sync pipeline data
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <idToken>" \
+  -H "Content-Type: application/json" \
+  -d '{"sheetId":"1AbCd…","tabGid":"0"}' \
+  http://localhost:4000/pipeline/sync
+```

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,7 @@ import healthRouter from './routes/health';
 import authRouter from './routes/auth';
 import sheetsRouter from './routes/sheets';
 import tabsRouter from './routes/tabs';
+import pipelineRouter from './routes/pipeline';
 import requireAuth from './middleware/requireAuth';
 import logger from './logger';
 import { getAuth } from './lib/googleClient';
@@ -25,6 +26,7 @@ app.use('/health-protected', requireAuth, (_req, res) => {
 app.use('/auth', authRouter);
 app.use('/sheets', requireAuth, sheetsRouter);
 app.use('/sheets', tabsRouter);
+app.use('/pipeline', pipelineRouter);
 
 app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
   logger.error(err.message);

--- a/backend/src/lib/settingsStore.ts
+++ b/backend/src/lib/settingsStore.ts
@@ -1,0 +1,25 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export interface PipelineSettings {
+  sheetId: string;
+  tabGid: string;
+}
+
+const SETTINGS_PATH = path.resolve(__dirname, '../../config/settings.json');
+
+export async function loadSettings(): Promise<PipelineSettings | null> {
+  try {
+    const data = await fs.readFile(SETTINGS_PATH, 'utf8');
+    return JSON.parse(data) as PipelineSettings;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveSettings(settings: PipelineSettings): Promise<void> {
+  await fs.mkdir(path.dirname(SETTINGS_PATH), { recursive: true });
+  const tmp = `${SETTINGS_PATH}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(settings, null, 2));
+  await fs.rename(tmp, SETTINGS_PATH);
+}

--- a/backend/src/routes/pipeline.ts
+++ b/backend/src/routes/pipeline.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import requireAuth from '../middleware/requireAuth';
+import syncPipeline from '../services/pipelineService';
+
+const router = Router();
+
+router.post('/sync', requireAuth, async (req, res) => {
+  const { sheetId, tabGid, force } = req.body || {};
+  if (!sheetId || !tabGid) {
+    return res.status(400).json({ error: 'sheetId and tabGid required' });
+  }
+  try {
+    const rows = await syncPipeline(
+      String(sheetId),
+      String(tabGid),
+      Boolean(force),
+    );
+    if (!rows) return res.status(404).json({ error: 'sheet or tab not found' });
+    return res.json(rows);
+  } catch (err) {
+    const e = err as { code?: number; message?: string };
+    if (e.code === 400) return res.status(400).json({ error: e.message });
+    if (e.code === 404)
+      return res.status(404).json({ error: 'sheet or tab not found' });
+    return res.status(502).json({ error: 'google api failure' });
+  }
+});
+
+export default router;

--- a/backend/src/services/pipelineService.ts
+++ b/backend/src/services/pipelineService.ts
@@ -1,0 +1,120 @@
+import { sheets } from '../lib/googleClient';
+import * as cache from '../lib/cache';
+import logger from '../logger';
+import { saveSettings } from '../lib/settingsStore';
+
+export interface RowObject {
+  [key: string]: string;
+}
+
+const CACHE_MS = 5 * 60 * 1000;
+
+function sanitizeKey(key: string): string {
+  return key.trim().replace(/\s+/g, '_').toLowerCase();
+}
+
+async function fetchTabTitle(
+  sheetId: string,
+  tabGid: string,
+): Promise<string | null> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await sheets.spreadsheets.get({
+        spreadsheetId: sheetId,
+        fields: 'sheets.properties',
+      });
+      const sheet = res.data.sheets?.find(
+        (s) => String(s.properties?.sheetId ?? '') === tabGid,
+      );
+      if (!sheet) return null;
+      return sheet.properties?.title || null;
+    } catch (err) {
+      if ((err as { code?: number }).code === 404) return null;
+      const delay = 2 ** attempt * 100;
+      logger.warn(
+        `Sheets get attempt ${attempt + 1} failed: ${(err as Error).message}`,
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, delay);
+      });
+    }
+  }
+  const error = new Error('google failure') as { code?: number };
+  error.code = 502;
+  throw error;
+}
+
+async function fetchValues(
+  sheetId: string,
+  title: string,
+): Promise<string[][] | null> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const res = await sheets.spreadsheets.values.get({
+        spreadsheetId: sheetId,
+        range: `'${title}'`,
+      });
+      return res.data.values || [];
+    } catch (err) {
+      if ((err as { code?: number }).code === 404) return null;
+      const delay = 2 ** attempt * 100;
+      logger.warn(
+        `Values get attempt ${attempt + 1} failed: ${(err as Error).message}`,
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, delay);
+      });
+    }
+  }
+  const error = new Error('google failure') as { code?: number };
+  error.code = 502;
+  throw error;
+}
+
+function convert(values: string[][]): RowObject[] {
+  if (!values[0]) {
+    const err = new Error('header row missing') as { code?: number };
+    err.code = 400;
+    throw err;
+  }
+  const headers = values[0].map((h) => sanitizeKey(h || ''));
+  if (headers.every((h) => h === '')) {
+    const err = new Error('header row missing') as { code?: number };
+    err.code = 400;
+    throw err;
+  }
+  return values.slice(1).map((row) => {
+    const obj: RowObject = {};
+    headers.forEach((k, i) => {
+      obj[k] = row[i] ?? '';
+    });
+    return obj;
+  });
+}
+
+export default async function sync(
+  sheetId: string,
+  tabGid: string,
+  force = false,
+): Promise<RowObject[] | null> {
+  const key = `${sheetId}|${tabGid}`;
+  if (!force) {
+    const cached = cache.get<RowObject[]>(key);
+    if (cached) return cached;
+  }
+
+  const title = await fetchTabTitle(sheetId, tabGid);
+  if (!title) return null;
+
+  const values = await fetchValues(sheetId, title);
+  if (values === null) return null;
+
+  const rows = convert(values);
+  cache.set(key, rows, CACHE_MS);
+  await saveSettings({ sheetId, tabGid });
+  return rows;
+}

--- a/backend/tests/pipeline.test.ts
+++ b/backend/tests/pipeline.test.ts
@@ -1,0 +1,142 @@
+import request from 'supertest';
+import { writeFileSync, readFileSync } from 'fs';
+import path from 'path';
+process.env.ALLOWED_USERS = 'user1@example.com';
+const dummyKey = path.join(__dirname, 'dummy.json');
+writeFileSync(dummyKey, '{}');
+process.env.SERVICE_ACCOUNT_JSON = dummyKey;
+import app from '../src/app';
+import * as cache from '../src/lib/cache';
+import { loadSettings } from '../src/lib/settingsStore';
+
+var mockedVerify: jest.Mock; // eslint-disable-line no-var
+var mockMetaGet: jest.Mock; // eslint-disable-line no-var
+var mockValuesGet: jest.Mock; // eslint-disable-line no-var
+
+jest.mock('google-auth-library', () => {
+  mockedVerify = jest.fn();
+  return {
+    OAuth2Client: function () {
+      return { verifyIdToken: mockedVerify };
+    },
+  };
+});
+
+jest.mock('../src/lib/googleClient', () => {
+  mockMetaGet = jest.fn();
+  mockValuesGet = jest.fn();
+  return {
+    getAuth: jest.fn(),
+    sheets: {
+      spreadsheets: {
+        get: mockMetaGet,
+        values: { get: mockValuesGet },
+      },
+    },
+    drive: {},
+  };
+});
+jest.mock('googleapis', () => ({
+  google: {
+    oauth2: () => ({
+      userinfo: {
+        get: jest
+          .fn()
+          .mockResolvedValue({ data: { email: 'test@example.com' } }),
+      },
+    }),
+  },
+}));
+
+describe('POST /pipeline/sync', () => {
+  beforeEach(() => {
+    mockedVerify.mockReset();
+    mockMetaGet.mockReset();
+    mockValuesGet.mockReset();
+    cache.clear('sheet|0');
+  });
+
+  it('syncs rows', async () => {
+    mockedVerify.mockResolvedValue({
+      getPayload: () => ({ email: 'user1@example.com' }),
+    });
+    mockMetaGet.mockResolvedValueOnce({
+      data: { sheets: [{ properties: { sheetId: 0, title: 'Data' } }] },
+    });
+    mockValuesGet.mockResolvedValueOnce({
+      data: {
+        values: [
+          ['Name', 'Email'],
+          ['Alice', 'a@example.com'],
+        ],
+      },
+    });
+    const res = await request(app)
+      .post('/pipeline/sync')
+      .set('Authorization', 'Bearer token')
+      .send({ sheetId: 'sheet', tabGid: '0' })
+      .expect(200);
+    expect(res.body).toEqual([{ name: 'Alice', email: 'a@example.com' }]);
+    const settings = await loadSettings();
+    expect(settings).toEqual({ sheetId: 'sheet', tabGid: '0' });
+  });
+
+  it('returns cached rows', async () => {
+    mockedVerify.mockResolvedValue({
+      getPayload: () => ({ email: 'user1@example.com' }),
+    });
+    mockMetaGet.mockResolvedValue({
+      data: { sheets: [{ properties: { sheetId: 0, title: 'Data' } }] },
+    });
+    mockValuesGet.mockResolvedValue({ data: { values: [['Name'], ['Bob']] } });
+    await request(app)
+      .post('/pipeline/sync')
+      .set('Authorization', 'Bearer token')
+      .send({ sheetId: 'sheet', tabGid: '0' })
+      .expect(200);
+    expect(mockMetaGet).toHaveBeenCalledTimes(1);
+    await request(app)
+      .post('/pipeline/sync')
+      .set('Authorization', 'Bearer token')
+      .send({ sheetId: 'sheet', tabGid: '0' })
+      .expect(200);
+    expect(mockMetaGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('force refresh bypasses cache', async () => {
+    mockedVerify.mockResolvedValue({
+      getPayload: () => ({ email: 'user1@example.com' }),
+    });
+    mockMetaGet.mockResolvedValue({
+      data: { sheets: [{ properties: { sheetId: 0, title: 'Data' } }] },
+    });
+    mockValuesGet.mockResolvedValue({ data: { values: [['H'], ['v1']] } });
+    await request(app)
+      .post('/pipeline/sync')
+      .set('Authorization', 'Bearer token')
+      .send({ sheetId: 'sheet', tabGid: '0' })
+      .expect(200);
+    mockValuesGet.mockResolvedValue({ data: { values: [['H'], ['v2']] } });
+    await request(app)
+      .post('/pipeline/sync')
+      .set('Authorization', 'Bearer token')
+      .send({ sheetId: 'sheet', tabGid: '0', force: true })
+      .expect(200);
+    expect(mockValuesGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns 404 for bad sheet', async () => {
+    mockedVerify.mockResolvedValue({
+      getPayload: () => ({ email: 'user1@example.com' }),
+    });
+    const err: any = new Error('not found');
+    err.code = 404;
+    mockMetaGet.mockRejectedValueOnce(err);
+    const res = await request(app)
+      .post('/pipeline/sync')
+      .set('Authorization', 'Bearer token')
+      .send({ sheetId: 'bad', tabGid: '0' })
+      .expect(404);
+    expect(res.body).toEqual({ error: 'sheet or tab not found' });
+  });
+});


### PR DESCRIPTION
## Summary
- implement pipeline sync API with caching
- persist selected sheet ID and tab ID
- add settings store and tests for pipeline sync
- document pipeline sync usage in README
- ignore generated settings file

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685b0eb171d48331bc44965940fce364