### PR TITLE
feat: cron refresh job and cached data endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,11 @@ curl -X POST \
   -d '{"sheetId":"1AbCd…","tabGid":"0"}' \
   http://localhost:4000/pipeline/sync
 ```
+
+Background refresh runs every 5 min.
+
+### Get cached data
+
+```bash
+curl -H "Authorization: Bearer <idToken>" http://localhost:4000/pipeline/data
+```

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "express-async-errors": "^3.1.1",
         "google-auth-library": "^8.9.0",
         "googleapis": "^118.0.0",
+        "node-cron": "^3.0.3",
         "winston": "^3.9.0",
         "zod": "^3.25.67"
       },
@@ -6495,6 +6496,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-fetch": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,11 +16,13 @@
     "express-async-errors": "^3.1.1",
     "google-auth-library": "^8.9.0",
     "googleapis": "^118.0.0",
+    "node-cron": "^3.0.3",
     "winston": "^3.9.0",
     "zod": "^3.25.67"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.12",
     "@types/node": "^20.8.6",
     "@typescript-eslint/eslint-plugin": "^8.35.0",
     "@typescript-eslint/parser": "^8.35.0",
@@ -29,12 +31,11 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.5.0",
-    "prettier": "^3.1.0",
-    "ts-node-dev": "^2.0.0",
-    "typescript": "^5.2.2",
     "jest": "^29.7.0",
+    "prettier": "^3.1.0",
+    "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "@types/jest": "^29.5.12",
-    "supertest": "^6.3.3"
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.2.2"
   }
 }

--- a/backend/src/cron/refreshJob.ts
+++ b/backend/src/cron/refreshJob.ts
@@ -1,0 +1,23 @@
+import cron from 'node-cron';
+import { loadSettings } from '../lib/settingsStore';
+import syncPipeline from '../services/pipelineService';
+import logger from '../logger';
+
+let started = false;
+export default function startRefreshJob() {
+  if (started) return;
+  started = true;
+  cron.schedule('*/5 * * * *', async () => {
+    try {
+      const settings = await loadSettings();
+      if (!settings) {
+        logger.info('Cron: no settings yet – skip');
+        return;
+      }
+      await syncPipeline(settings.sheetId, settings.tabGid, true);
+      logger.info(`Cron: refreshed ${settings.sheetId}/${settings.tabGid}`);
+    } catch (err) {
+      logger.error(`Cron refresh failed: ${(err as Error).message}`);
+    }
+  });
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,9 @@
 import app from './app';
 import logger from './logger';
 import { PORT } from './config';
+import startRefreshJob from './cron/refreshJob';
 
 app.listen(PORT, () => {
   logger.info(`Server listening on port ${PORT}`);
+  startRefreshJob();
 });

--- a/backend/src/routes/pipeline.ts
+++ b/backend/src/routes/pipeline.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import requireAuth from '../middleware/requireAuth';
 import syncPipeline from '../services/pipelineService';
+import * as cache from '../lib/cache';
 
 const router = Router();
 
@@ -24,6 +25,12 @@ router.post('/sync', requireAuth, async (req, res) => {
       return res.status(404).json({ error: 'sheet or tab not found' });
     return res.status(502).json({ error: 'google api failure' });
   }
+});
+
+router.get('/data', requireAuth, (req, res) => {
+  const rows = cache.get('data:last');
+  if (!rows) return res.status(404).json({ error: 'no data' });
+  return res.json(rows);
 });
 
 export default router;

--- a/backend/src/services/pipelineService.ts
+++ b/backend/src/services/pipelineService.ts
@@ -115,6 +115,7 @@ export default async function sync(
 
   const rows = convert(values);
   cache.set(key, rows, CACHE_MS);
+  cache.set('data:last', rows, CACHE_MS);
   await saveSettings({ sheetId, tabGid });
   return rows;
 }

--- a/backend/tests/cron.test.ts
+++ b/backend/tests/cron.test.ts
@@ -1,0 +1,50 @@
+import { writeFileSync } from 'fs';
+import path from 'path';
+process.env.ALLOWED_USERS = 'user1@example.com';
+const dummyKey = path.join(__dirname, 'dummy.json');
+writeFileSync(dummyKey, '{}');
+process.env.SERVICE_ACCOUNT_JSON = dummyKey;
+
+jest.mock('node-cron', () => ({ schedule: jest.fn() }));
+
+let cron: any = require('node-cron');
+
+describe('refresh cron job', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    cron = require('node-cron');
+    (cron.schedule as jest.Mock).mockReset();
+  });
+
+  it('calls sync when settings present', async () => {
+    jest.doMock('../src/lib/settingsStore', () => ({
+      loadSettings: jest.fn().mockResolvedValue({ sheetId: 's', tabGid: '1' }),
+    }));
+    jest.doMock('../src/services/pipelineService', () => ({
+      __esModule: true,
+      default: jest.fn().mockResolvedValue([]),
+    }));
+    const startRefreshJob = require('../src/cron/refreshJob').default;
+    const sync = require('../src/services/pipelineService').default;
+    startRefreshJob();
+    const fn = (cron.schedule as jest.Mock).mock.calls[0][1];
+    await fn();
+    expect(sync).toHaveBeenCalledWith('s', '1', true);
+  });
+
+  it('skips when settings missing', async () => {
+    jest.doMock('../src/lib/settingsStore', () => ({
+      loadSettings: jest.fn().mockResolvedValue(null),
+    }));
+    jest.doMock('../src/services/pipelineService', () => ({
+      __esModule: true,
+      default: jest.fn(),
+    }));
+    const startRefreshJob = require('../src/cron/refreshJob').default;
+    const sync = require('../src/services/pipelineService').default;
+    startRefreshJob();
+    const fn = (cron.schedule as jest.Mock).mock.calls[0][1];
+    await fn();
+    expect(sync).not.toHaveBeenCalled();
+  });
+});

--- a/backend/tests/pipelineData.test.ts
+++ b/backend/tests/pipelineData.test.ts
@@ -1,0 +1,66 @@
+import request from 'supertest';
+import { writeFileSync } from 'fs';
+import path from 'path';
+process.env.ALLOWED_USERS = 'user1@example.com';
+const dummyKey = path.join(__dirname, 'dummy.json');
+writeFileSync(dummyKey, '{}');
+process.env.SERVICE_ACCOUNT_JSON = dummyKey;
+import app from '../src/app';
+import * as cache from '../src/lib/cache';
+
+var mockedVerify: jest.Mock; // eslint-disable-line no-var
+
+jest.mock('google-auth-library', () => {
+  mockedVerify = jest.fn();
+  return {
+    OAuth2Client: function () {
+      return { verifyIdToken: mockedVerify };
+    },
+  };
+});
+jest.mock('../src/lib/googleClient', () => ({
+  getAuth: jest.fn(),
+  sheets: {},
+  drive: {},
+}));
+jest.mock('googleapis', () => ({
+  google: {
+    oauth2: () => ({
+      userinfo: {
+        get: jest
+          .fn()
+          .mockResolvedValue({ data: { email: 'test@example.com' } }),
+      },
+    }),
+  },
+}));
+
+describe('GET /pipeline/data', () => {
+  beforeEach(() => {
+    mockedVerify.mockReset();
+    cache.clear('data:last');
+  });
+
+  it('returns cached rows', async () => {
+    mockedVerify.mockResolvedValue({
+      getPayload: () => ({ email: 'user1@example.com' }),
+    });
+    cache.set('data:last', [{ name: 'Alice' }], 1000);
+    const res = await request(app)
+      .get('/pipeline/data')
+      .set('Authorization', 'Bearer token')
+      .expect(200);
+    expect(res.body).toEqual([{ name: 'Alice' }]);
+  });
+
+  it('returns 404 when missing', async () => {
+    mockedVerify.mockResolvedValue({
+      getPayload: () => ({ email: 'user1@example.com' }),
+    });
+    const res = await request(app)
+      .get('/pipeline/data')
+      .set('Authorization', 'Bearer token')
+      .expect(404);
+    expect(res.body).toEqual({ error: 'no data' });
+  });
+});


### PR DESCRIPTION
## Summary
- add node-cron and implement periodic refresh job
- expose GET `/pipeline/data` to return last synced rows
- cache latest rows on sync
- wire up refresh job at server start
- document new endpoint and background refresh
- add unit tests for cron job and data endpoint

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_685b11a1c1dc8331ae685d29627eaf11