### PR TITLE
feat: logging and error UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,13 @@ Background refresh runs every 5 min.
 ```bash
 curl -H "Authorization: Bearer <idToken>" http://localhost:4000/pipeline/data
 ```
+
+## Logs & Errors
+
+The backend writes structured logs with timestamps and log levels. When running via Docker you can view them with:
+
+```bash
+docker compose logs -f backend
+```
+
+Errors from API requests are returned as JSON and surfaced in the UI via toast notifications displayed in the top-right corner.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,5 @@
 import 'express-async-errors';
-import express, { Request, Response, NextFunction } from 'express';
+import express from 'express';
 import { google } from 'googleapis';
 import healthRouter from './routes/health';
 import authRouter from './routes/auth';
@@ -8,6 +8,7 @@ import tabsRouter from './routes/tabs';
 import pipelineRouter from './routes/pipeline';
 import requireAuth from './middleware/requireAuth';
 import logger from './logger';
+import errorHandler from './middleware/errorHandler';
 import { getAuth } from './lib/googleClient';
 
 const app = express();
@@ -28,10 +29,7 @@ app.use('/sheets', requireAuth, sheetsRouter);
 app.use('/sheets', tabsRouter);
 app.use('/pipeline', pipelineRouter);
 
-app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
-  logger.error(err.message);
-  res.status(500).json({ error: 'Internal Server Error' });
-});
+app.use(errorHandler);
 
 if (process.env.NODE_ENV !== 'test') {
   (async () => {

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,9 +1,21 @@
 import winston from 'winston';
 import { env } from './config';
 
+const level = env.LOG_LEVEL || 'info';
+
+const baseFormat = winston.format.combine(
+  winston.format.timestamp(),
+  process.env.NODE_ENV === 'production'
+    ? winston.format.json()
+    : winston.format.combine(
+        winston.format.colorize(),
+        winston.format.simple(),
+      ),
+);
+
 const logger = winston.createLogger({
-  level: env.LOG_LEVEL || 'info',
-  format: winston.format.simple(),
+  level,
+  format: baseFormat,
   transports: [new winston.transports.Console()],
 });
 

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from 'express';
+import logger from '../logger';
+
+interface HttpError extends Error {
+  httpStatus?: number;
+}
+
+export default function errorHandler(
+  err: HttpError,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+) {
+  logger.error(err.message, { stack: err.stack });
+  const status = err.httpStatus || 500;
+  res.status(status).json({ error: err.message });
+}

--- a/backend/tests/errorHandler.test.ts
+++ b/backend/tests/errorHandler.test.ts
@@ -1,0 +1,27 @@
+import request from 'supertest';
+import { writeFileSync } from 'fs';
+import path from 'path';
+
+process.env.ALLOWED_USERS = 'user1@example.com';
+const dummyKey = path.join(__dirname, 'dummy.json');
+writeFileSync(dummyKey, '{}');
+process.env.SERVICE_ACCOUNT_JSON = dummyKey;
+
+import express from 'express';
+import logger from '../src/logger';
+import errorHandler from '../src/middleware/errorHandler';
+
+const app = express();
+app.get('/throw', () => {
+  throw new Error('boom');
+});
+app.use(errorHandler);
+
+describe('error handler', () => {
+  it('returns 500 json and logs once', async () => {
+    const spy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+    const res = await request(app).get('/throw').expect(500);
+    expect(res.body).toEqual({ error: 'boom' });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import PipelineFilter from './components/PipelineFilter';
 import SettingsModal from './components/SettingsModal';
 import { UploadIcon, SettingsIcon } from './components/Icons';
 import { shortenName } from './utils';
+import ErrorToastProvider from './components/ErrorToastProvider';
 
 // --- INITIAL STATE ---
 const initialCandidates = [];
@@ -65,6 +66,7 @@ const App = () => {
   };
 
   return (
+    <ErrorToastProvider>
     <div className="bg-gray-50 min-h-screen w-full font-sans">
       {allCandidates.length === 0 ? (
         <div className="flex flex-col items-center justify-center min-h-screen w-full p-4">
@@ -160,6 +162,7 @@ const App = () => {
         </div>
       )}
     </div>
+    </ErrorToastProvider>
   );
 };
 

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest';
+import toast from 'react-hot-toast';
+import { apiFetch } from '../lib/api';
+
+describe('apiFetch', () => {
+  it('shows toast on error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      json: vi.fn().mockResolvedValue({ error: 'fail' }),
+    } as any);
+    const toastSpy = vi.spyOn(toast, 'error').mockImplementation(() => '');
+    await expect(apiFetch('/x')).rejects.toThrow('fail');
+    expect(toastSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/ErrorToastProvider.tsx
+++ b/src/components/ErrorToastProvider.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+import { Toaster } from 'react-hot-toast';
+
+interface Props { children: ReactNode }
+
+export default function ErrorToastProvider({ children }: Props) {
+  return (
+    <>
+      {children}
+      <Toaster toastOptions={{ className: 'z-50' }} position="top-right" />
+    </>
+  );
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { CloseIcon, UploadIcon } from './Icons';
-import toast from 'react-hot-toast';
-import api from '../lib/api';
+import api, { success } from '../lib/api';
 
 interface Props {
   open: boolean;
@@ -101,17 +100,10 @@ const SettingsModal: React.FC<Props> = ({ open, onClose }) => {
       if (!sheetId || !tabGid) return;
       setSyncing(true);
       try {
-        const res = await api.post('/pipeline/sync', { sheetId, tabGid });
-        if (res.ok) {
-          toast.success('Data synced');
-        } else {
-          const json = await res.json().catch(() => ({}));
-          console.error(json);
-          toast.error('Sync failed');
-        }
+        await api.post('/pipeline/sync', { sheetId, tabGid });
+        success('Data synced');
       } catch (err) {
         console.error(err);
-        toast.error('Sync failed');
       } finally {
         setSyncing(false);
       }
@@ -120,7 +112,7 @@ const SettingsModal: React.FC<Props> = ({ open, onClose }) => {
       if (!selectedFile) return;
       const reader = new FileReader();
       reader.onload = () => {
-        toast.success('CSV loaded');
+        success('CSV loaded');
         onClose();
       };
       reader.readAsText(selectedFile);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,29 +1,41 @@
+import toast from 'react-hot-toast';
+
+function addAuth(options: any = {}) {
+  const idToken = localStorage.getItem('idToken') || '';
+  return {
+    ...options,
+    headers: {
+      ...(options.headers || {}),
+      Authorization: `Bearer ${idToken}`,
+    },
+  };
+}
+
+export async function apiFetch(url: string, options: any = {}) {
+  const res = await fetch(url, addAuth(options));
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    toast.error('Action failed – see console for details');
+    console.error('API error', url, data);
+    throw new Error(data.error || 'Unknown error');
+  }
+  return res.json();
+}
+
 export const api = {
-  get: async (url: string, options: any = {}) => {
-    const idToken = localStorage.getItem('idToken') || '';
-    const res = await fetch(url, {
+  get: (url: string, options: any = {}) => apiFetch(url, { ...options, method: 'GET' }),
+  post: (url: string, body: unknown, options: any = {}) =>
+    apiFetch(url, {
       ...options,
-      headers: {
-        ...(options.headers || {}),
-        Authorization: `Bearer ${idToken}`,
-      },
-    });
-    return res;
-  },
-  post: async (url: string, body: unknown, options: any = {}) => {
-    const idToken = localStorage.getItem('idToken') || '';
-    const res = await fetch(url, {
       method: 'POST',
       body: JSON.stringify(body),
       headers: {
         'Content-Type': 'application/json',
         ...(options.headers || {}),
-        Authorization: `Bearer ${idToken}`,
       },
-      ...options,
-    });
-    return res;
-  },
+    }),
 };
+
+export const success = (msg: string) => toast.success(msg);
 
 export default api;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,12 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { Toaster } from 'react-hot-toast'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />
-    <Toaster />
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- use winston logger formatting with JSON in prod
- centralize Express error handling
- wrap app in `ErrorToastProvider`
- show toast and console message on API errors
- document logs and toasts in README
- remove binary screenshot from repo

## Testing
- `npm run lint`
- `npm --prefix backend run lint`
- `npm test`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_b_685b17deb09c8331b1f35c53adb07794